### PR TITLE
Add track orientation, industries and players

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This project is a tiny demo inspired by **Transport Tycoon Deluxe**. It now
 supports multiple players connecting through a simple Socket.IO server. Players
-share the same map and can place track tiles together in real time.
+share the same map, build tracks with proper orientations and spawn trains that
+travel along them. A couple of demo industries are shown on the grid.
 
 ## Requirements
 
@@ -35,8 +36,9 @@ together.
 ## Game controls
 
 - **Click** on a grid cell to place or remove a track tile.
-- Press **Space** to start the train once the first cell has track.
-- The train generates $100 every time it reaches the end of the line.
+- Press **Space** to spawn a train on the existing track.
+- Each train that reaches a dead end earns $100.
+- Industries are displayed on the map and more than one player can join.
 
 ## Project structure
 

--- a/public/client.js
+++ b/public/client.js
@@ -4,6 +4,9 @@
  */
 
 const socket = io();
+// Ask the player for a name when they join
+const playerName = prompt('Enter your name') || 'Anonymous';
+socket.emit('register', playerName);
 
 // Canvas setup
 const canvas = document.getElementById('gameCanvas');
@@ -17,45 +20,67 @@ const cellSize = canvas.width / cols; // assumes square canvas
 // Game state received from the server
 const grid = [];
 let money = 0;
-const train = {
-  x: -1,
-  y: 10,
-  speed: 0.1,
-  progress: 0,
-  active: false,
-};
+const trains = [];
+const industries = [];
+let settings = {};
 
-// Draw grid and train
+// Compute track connections for a cell
+function getConnections(x, y) {
+  const c = { n: false, e: false, s: false, w: false };
+  if (!grid[y] || grid[y][x] !== 1) return c;
+  if (y > 0 && grid[y - 1][x] === 1) c.n = true;
+  if (x < cols - 1 && grid[y][x + 1] === 1) c.e = true;
+  if (y < rows - 1 && grid[y + 1][x] === 1) c.s = true;
+  if (x > 0 && grid[y][x - 1] === 1) c.w = true;
+  return c;
+}
+
+// Draw grid, industries and trains
 function draw() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  // Draw each cell
+  // Draw each cell and any track
   for (let y = 0; y < rows; y++) {
     for (let x = 0; x < cols; x++) {
       ctx.strokeStyle = '#ddd';
       ctx.strokeRect(x * cellSize, y * cellSize, cellSize, cellSize);
       if (grid[y] && grid[y][x] === 1) {
-        // track cell
-        ctx.fillStyle = '#444';
-        ctx.fillRect(
-          x * cellSize + cellSize * 0.25,
-          y * cellSize + cellSize * 0.45,
-          cellSize * 0.5,
-          cellSize * 0.1
-        );
+        const con = getConnections(x, y);
+        ctx.strokeStyle = '#444';
+        ctx.lineWidth = cellSize * 0.1;
+        ctx.beginPath();
+        const cx = x * cellSize + cellSize / 2;
+        const cy = y * cellSize + cellSize / 2;
+        if (con.n) { ctx.moveTo(cx, cy); ctx.lineTo(cx, y * cellSize); }
+        if (con.e) { ctx.moveTo(cx, cy); ctx.lineTo((x + 1) * cellSize, cy); }
+        if (con.s) { ctx.moveTo(cx, cy); ctx.lineTo(cx, (y + 1) * cellSize); }
+        if (con.w) { ctx.moveTo(cx, cy); ctx.lineTo(x * cellSize, cy); }
+        ctx.stroke();
       }
     }
   }
 
-  // Draw train if active
-  if (train.active) {
+  // Draw industries
+  industries.forEach((ind) => {
+    ctx.fillStyle = ind.type === 'Mine' ? '#964B00' : '#0066cc';
+    ctx.fillRect(
+      ind.x * cellSize + cellSize * 0.1,
+      ind.y * cellSize + cellSize * 0.1,
+      cellSize * 0.8,
+      cellSize * 0.8
+    );
+  });
+
+  // Draw all trains
+  trains.forEach((t) => {
+    if (!t.active) return;
     ctx.fillStyle = 'red';
-    const tx = (train.x + train.progress) * cellSize + cellSize / 2;
-    const ty = train.y * cellSize + cellSize / 2;
+    const tx = (t.x + t.progress) * cellSize + cellSize / 2;
+    const ty = (t.y + 0.5) * cellSize;
     ctx.beginPath();
     ctx.arc(tx, ty, cellSize * 0.3, 0, Math.PI * 2);
     ctx.fill();
-  }
+  });
 }
 
 // Animation loop only draws; state comes from the server
@@ -70,7 +95,11 @@ socket.on('init', (state) => {
   for (let y = 0; y < rows; y++) {
     grid[y] = state.grid[y].slice();
   }
-  Object.assign(train, state.train);
+  trains.length = 0;
+  state.trains.forEach((t) => trains.push({ ...t }));
+  industries.length = 0;
+  state.industries.forEach((i) => industries.push(i));
+  settings = state.settings;
   money = state.money;
   document.getElementById('money').textContent = `Money: $${money}`;
   draw();
@@ -84,8 +113,25 @@ socket.on('updateGrid', (serverGrid) => {
 });
 
 // Train position updates
-socket.on('state', ({ train: serverTrain }) => {
-  Object.assign(train, serverTrain);
+socket.on('state', ({ trains: serverTrains }) => {
+  for (let i = 0; i < serverTrains.length; i++) {
+    if (trains[i]) {
+      Object.assign(trains[i], serverTrains[i]);
+    } else {
+      trains[i] = { ...serverTrains[i] };
+    }
+  }
+  trains.length = serverTrains.length;
+});
+
+// A train spawned by another player
+socket.on('trainSpawn', (train) => {
+  trains.push(train);
+});
+
+// Update list of connected players
+socket.on('playerList', (list) => {
+  document.getElementById('players').textContent = `Players: ${list.join(', ')}`;
 });
 
 // Money updates

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
     </div>
     <div id="info">
         <span id="money">Money: $0</span>
+        <div id="players"></div>
     </div>
     <script src="/socket.io/socket.io.js"></script>
     <script src="client.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -15,3 +15,8 @@ body {
     margin-top: 10px;
     font-size: 18px;
 }
+
+#players {
+    margin-top: 5px;
+    font-size: 14px;
+}

--- a/server.js
+++ b/server.js
@@ -12,21 +12,104 @@ app.use(express.static('public'));
 // Basic game state shared by all players
 const rows = 20;
 const cols = 20;
+// grid[y][x] == 1 indicates track present
 const grid = Array.from({ length: rows }, () => new Array(cols).fill(0));
 let money = 0;
 
-// Train starts off the map to the left
-const train = {
-  x: -1,
-  y: 10,
-  speed: 0.1,
-  progress: 0,
-  active: false,
+// Simple industries at fixed positions
+const industries = [
+  { x: 2, y: 2, type: 'Mine' },
+  { x: 17, y: 17, type: 'Factory' },
+];
+
+// Default game settings shared with clients
+const settings = {
+  trainSpeed: 0.1,
 };
 
-// When clients connect, send them the current game state
+// Map of socket.id -> player name
+const players = new Map();
+
+// All active trains
+const trains = [];
+
+/**
+ * Spawn a new train starting on the first track tile in row 10.
+ * Returns the created train or null if no starting track.
+ */
+function spawnTrain() {
+  if (grid[10][0] !== 1) return null;
+  const train = {
+    x: 0,
+    y: 10,
+    dx: 1,
+    dy: 0,
+    speed: settings.trainSpeed,
+    progress: 0,
+    active: true,
+  };
+  trains.push(train);
+  return train;
+}
+
+// Determine track connections around a cell
+function getConnections(x, y) {
+  const c = { n: false, e: false, s: false, w: false };
+  if (!grid[y][x]) return c;
+  if (y > 0 && grid[y - 1][x]) c.n = true;
+  if (x < cols - 1 && grid[y][x + 1]) c.e = true;
+  if (y < rows - 1 && grid[y + 1][x]) c.s = true;
+  if (x > 0 && grid[y][x - 1]) c.w = true;
+  return c;
+}
+
+// Move a train one tile according to the track layout
+function moveTrain(train) {
+  if (!train.active) return;
+  train.progress += train.speed;
+  if (train.progress < 1) return;
+
+  const nx = train.x + train.dx;
+  const ny = train.y + train.dy;
+  if (nx >= 0 && nx < cols && ny >= 0 && ny < rows && grid[ny][nx] === 1) {
+    train.x = nx;
+    train.y = ny;
+    train.progress = 0;
+    return;
+  }
+
+  const con = getConnections(train.x, train.y);
+  const opts = [];
+  if (con.n && train.dy !== 1) opts.push({ dx: 0, dy: -1 });
+  if (con.e && train.dx !== -1) opts.push({ dx: 1, dy: 0 });
+  if (con.s && train.dy !== -1) opts.push({ dx: 0, dy: 1 });
+  if (con.w && train.dx !== 1) opts.push({ dx: -1, dy: 0 });
+
+  if (opts.length) {
+    const o = opts[0];
+    train.dx = o.dx;
+    train.dy = o.dy;
+    train.x += train.dx;
+    train.y += train.dy;
+    train.progress = 0;
+  } else {
+    train.active = false;
+  }
+}
+
+// When clients connect, register player and send current state
 io.on('connection', (socket) => {
-  socket.emit('init', { grid, money, train });
+  socket.on('register', (name) => {
+    players.set(socket.id, name || 'Anonymous');
+    io.emit('playerList', Array.from(players.values()));
+  });
+
+  socket.emit('init', { grid, money, trains, industries, settings });
+
+  socket.on('disconnect', () => {
+    players.delete(socket.id);
+    io.emit('playerList', Array.from(players.values()));
+  });
 
   // Toggle a track tile and broadcast the new grid
   socket.on('toggleTrack', ({ x, y }) => {
@@ -36,37 +119,31 @@ io.on('connection', (socket) => {
     }
   });
 
-  // Request to start the train
+  // Request to spawn a new train
   socket.on('startTrain', () => {
-    if (!train.active && grid[train.y][0] === 1) {
-      train.active = true;
-      train.x = 0;
-      train.progress = 0;
+    const train = spawnTrain();
+    if (train) {
+      io.emit('trainSpawn', train);
     }
   });
 });
 
-// Update train position on the server
-function updateTrain() {
-  if (!train.active) return;
-  train.progress += train.speed;
-  if (train.progress >= 1) {
-    train.x += 1;
-    train.progress = 0;
-    // Check if track continues
-    if (train.x >= cols || grid[train.y][train.x] !== 1) {
-      train.active = false;
-      train.x = -1;
-      money += 100; // reward for successful delivery
+// Update all trains and reward deliveries
+function updateTrains() {
+  trains.forEach((t) => moveTrain(t));
+  for (let i = trains.length - 1; i >= 0; i--) {
+    if (!trains[i].active) {
+      money += 100;
       io.emit('moneyUpdate', money);
+      trains.splice(i, 1);
     }
   }
 }
 
 // Game loop running on the server
 setInterval(() => {
-  updateTrain();
-  io.emit('state', { train });
+  updateTrains();
+  io.emit('state', { trains });
 }, 1000 / 60);
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add server support for multiple trains, industries and players
- draw tracks with correct orientations on the client
- show industries and player list
- document new controls and behaviour

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6884a9ed341483289705ce20f09445ea