### PR TITLE
Add per-player coloured tracks and improve train handling

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -27,11 +27,11 @@ let settings = {};
 // Compute track connections for a cell
 function getConnections(x, y) {
   const c = { n: false, e: false, s: false, w: false };
-  if (!grid[y] || grid[y][x] !== 1) return c;
-  if (y > 0 && grid[y - 1][x] === 1) c.n = true;
-  if (x < cols - 1 && grid[y][x + 1] === 1) c.e = true;
-  if (y < rows - 1 && grid[y + 1][x] === 1) c.s = true;
-  if (x > 0 && grid[y][x - 1] === 1) c.w = true;
+  if (!grid[y] || !grid[y][x]) return c;
+  if (y > 0 && grid[y - 1][x]) c.n = true;
+  if (x < cols - 1 && grid[y][x + 1]) c.e = true;
+  if (y < rows - 1 && grid[y + 1][x]) c.s = true;
+  if (x > 0 && grid[y][x - 1]) c.w = true;
   return c;
 }
 
@@ -44,9 +44,10 @@ function draw() {
     for (let x = 0; x < cols; x++) {
       ctx.strokeStyle = '#ddd';
       ctx.strokeRect(x * cellSize, y * cellSize, cellSize, cellSize);
-      if (grid[y] && grid[y][x] === 1) {
+      if (grid[y] && grid[y][x]) {
         const con = getConnections(x, y);
-        ctx.strokeStyle = '#444';
+        // Use the track owner's colour when drawing
+        ctx.strokeStyle = grid[y][x].color || '#444';
         ctx.lineWidth = cellSize * 0.1;
         ctx.beginPath();
         const cx = x * cellSize + cellSize / 2;


### PR DESCRIPTION
## Summary
- set up grid cells to include track owner and colour
- assign colours to players on registration
- draw tracks using the owner's colour on the client
- update train logic to work with new grid objects

## Testing
- `./setup.sh`
- `npm start` (server runs)


------
https://chatgpt.com/codex/tasks/task_e_6884ae1d3770832884ad941d1c4bfce3