### PR TITLE
Add Raspberry Pi hosting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ travel along them. A couple of demo industries are shown on the grid.
    browser windows or share the URL with friends on the same network to play
 together.
 
+## Hosting on a Raspberry Pi
+
+Use the provided `host.sh` script to quickly run the server on a Raspberry Pi.
+Pass an optional port number to change the default (`3000`):
+
+```bash
+./host.sh 8080
+```
+
+If no port is supplied, the server listens on port 3000.
+
 ## Game controls
 
 - **Click** on a grid cell to place or remove a track tile.

--- a/host.sh
+++ b/host.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# host.sh - Launch the Transport Tycoon Basic server on a Raspberry Pi.
+# Usage: ./host.sh [PORT]
+# The optional PORT argument sets the HTTP port. Defaults to 3000.
+
+# Pick port from argument or use default
+PORT="${1:-3000}"
+
+# Ensure dependencies are installed. This check keeps first run simple.
+if [ ! -d node_modules ]; then
+  echo "Installing dependencies..."
+  npm install
+fi
+
+# Start the server with the specified port
+# PORT is an environment variable read in server.js
+PORT="$PORT" node server.js


### PR DESCRIPTION
## Summary
- add `host.sh` for easy deployment on Raspberry Pi
- document Raspberry Pi hosting instructions

## Testing
- `npm start` (server started on port 3000)
- `./host.sh 4000` (server started on port 4000)

------
https://chatgpt.com/codex/tasks/task_e_6884b2d6f314832897c9a9408f50b077