### PR TITLE
Add Windows hosting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ travel along them. A couple of demo industries are shown on the grid.
    ./setup.sh
    ```
 
-   The script installs all required Node.js packages.
-   If you are on **Windows**, open a terminal that can run shell scripts, such
-   as **Git Bash** or **WSL**, and execute the command above. If you prefer using
-   Command Prompt or PowerShell, run `npm install` manually instead of the
-   script.
+   The script installs all required Node.js packages. On **Windows** you can
+   either run it from a terminal that understands shell scripts (such as
+   **Git Bash** or **WSL**) or simply execute `npm install` manually. A
+   Windows-specific helper script `host.bat` is also provided for convenience.
 3. Start the server:
 
    ```bash
@@ -43,6 +42,18 @@ Pass an optional port number to change the default (`3000`):
 ```
 
 If no port is supplied, the server listens on port 3000.
+
+## Hosting on Windows
+
+Run the `host.bat` script to install dependencies, perform any available
+migrations or builds and start the server. An optional port argument sets the
+port (default is `3000`):
+
+```cmd
+host.bat 8080
+```
+
+Omit the argument to use the default port.
 
 ## Game controls
 

--- a/host.bat
+++ b/host.bat
@@ -1,0 +1,24 @@
+@echo off
+REM host.bat - Launch the Transport Tycoon Basic server on Windows.
+REM Usage: host.bat [PORT]
+REM The optional PORT argument sets the HTTP port. Defaults to 3000.
+
+REM Choose provided port or default value
+SET PORT=%1
+IF "%PORT%"=="" SET PORT=3000
+
+REM Install dependencies on first run
+IF NOT EXIST node_modules (
+  echo Installing dependencies...
+  npm install
+)
+
+REM Optional migration step
+call npm run migrate >NUL 2>&1
+
+REM Optional build step
+call npm run build >NUL 2>&1
+
+REM Launch the server on the specified port
+SET PORT=%PORT%
+node server.js


### PR DESCRIPTION
## Summary
- provide host.bat for Windows users
- document Windows hosting in the README

## Testing
- `npm install`
- `PORT=4000 node server.js &`

------
https://chatgpt.com/codex/tasks/task_e_68850187b860832880028b228bbafd2a